### PR TITLE
FB4-781 rootfs on 2.7 is almost full - objective: free a few %

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,14 @@
 LIBNAME = media-stream-library
+DEBUG?=no
+
+ifeq ($(DEBUG), yes)
+YARN_TARGET = build:bundle-dev
 INSTALL_FILE_IN = dist/media-stream-library.legacy.dev.js
+else
+YARN_TARGET = build:bundle-legacy
+INSTALL_FILE_IN = dist/media-stream-library.legacy.min.js
+endif
+
 INSTALL_FILE_OUT = media-stream-library.js
 EXTRA_INSTALL_FILES = 
 
@@ -28,7 +37,7 @@ build:
 	@echo ==================================
 	@echo "Building $(LIBNAME)"
 	@echo ==================================
-	yarn build:bundle-dev
+	yarn $(YARN_TARGET)
 
 install:
 ifndef DESTDIR 
@@ -45,6 +54,6 @@ clean:
 	@echo ==================================
 	@echo "Cleaning $(LIBNAME)"
 	@echo ==================================
-	@rm -f $(INSTALL_FILE_IN)
+	@rm -f dist/*
 
 .PHONY: default usage prepare build install clean


### PR DESCRIPTION
This makefile defaults the build to production mode instead of development mode. This gives a minified output with file size that is only around 10% of that for development mode.

Jira Link (use notation [PROJECT-123]): https://ovationsystems.atlassian.net/browse/FB4-781
Problem / Feature: See Jira
Solution: Reduce the size of file media-stream-library.js (see commit message)
Testing: Have tested in a local build. Kevin to test in a full private build.
Jira or PR for parallel or older branches: <Enter link to Jira or another PR or delete this if not needed>
Concerns: None
Expert Reviewers: Any
Sections to be Reviewed: All
Expected maximum review time: 3 minutes

