### PR TITLE
FB5-1583 Add support for SHA-256 RTSP digest for Web Page Live button

### DIFF
--- a/lib/components/auth/digest.ts
+++ b/lib/components/auth/digest.ts
@@ -1,12 +1,13 @@
 // https://tools.ietf.org/html/rfc2617#section-3.2.1
 import { Md5 as MD5 } from 'ts-md5'
 import { ChallengeParams } from './www-authenticate'
+import { sha256 } from 'js-sha256';
 
 export class DigestAuth {
   private readonly realm: string
   private readonly nonce: string
   private readonly opaque?: string
-  private readonly algorithm?: 'md5' | 'md5-sess'
+  private readonly algorithm?: 'md5' | 'md5-sess' | 'sha-256'
   private readonly qop?: 'auth' | 'auth-int'
   private readonly username: string
 
@@ -19,10 +20,6 @@ export class DigestAuth {
       throw new Error('no realm in digest challenge')
     }
     this.realm = realm
-    this.ha1Base = new MD5()
-      .appendStr(`${username}:${realm}:${password}`)
-      .end()
-      .toString()
 
     const nonce = params.get('nonce')
     if (nonce === undefined) {
@@ -32,15 +29,29 @@ export class DigestAuth {
 
     this.opaque = params.get('opaque')
 
-    const algorithm = params.get('algorithm')
+    let algorithm = params.get('algorithm')
     if (algorithm !== undefined) {
+      algorithm = algorithm.toLowerCase()
       if (algorithm === 'md5') {
         this.algorithm = 'md5'
       } else if (algorithm === 'md5-sess') {
         this.algorithm = 'md5-sess'
+      } else if (algorithm === 'sha-256') {
+        this.algorithm = 'sha-256'
       }
     } else {
       this.algorithm = 'md5'
+    }
+
+    if (this.algorithm === 'sha-256') {
+      let hash = sha256.create()
+      hash.update(`${username}:${realm}:${password}`)
+      this.ha1Base = hash.hex()
+    } else {
+      this.ha1Base = new MD5()
+        .appendStr(`${username}:${realm}:${password}`)
+        .end()
+        .toString()
     }
 
     const qop = params.get('qop')
@@ -82,12 +93,19 @@ export class DigestAuth {
   }
 
   ha2 = (method: string, uri: string, body = ''): string => {
-    let ha2 = new MD5().appendStr(`${method}:${uri}`).end().toString()
-    if (this.algorithm === 'md5-sess') {
-      const hbody = new MD5().appendStr(body).end().toString()
-      ha2 = new MD5().appendStr(`${method}:${uri}:${hbody}`).end().toString()
+    if (this.algorithm === 'sha-256') {
+      let hash = sha256.create()
+      hash.update(`${method}:${uri}`)
+      let ha2 = hash.hex()
+      return ha2
+    } else {
+      let ha2 = new MD5().appendStr(`${method}:${uri}`).end().toString()
+      if (this.algorithm === 'md5-sess') {
+        const hbody = new MD5().appendStr(body).end().toString()
+        ha2 = new MD5().appendStr(`${method}:${uri}:${hbody}`).end().toString()
+      }
+      return ha2
     }
-    return ha2
   }
 
   authorization = (method = 'GET', uri = '', body?: string): string => {
@@ -98,17 +116,28 @@ export class DigestAuth {
     const ha1 = this.ha1(cnonce)
     const ha2 = this.ha2(method, uri, body)
 
-    const response =
-      this.qop === undefined
-        ? new MD5().appendStr(`${ha1}:${this.nonce}:${ha2}`).end().toString()
-        : new MD5()
+    if (this.algorithm === 'sha-256') {
+      let hash = sha256.create()
+      if (this.qop === undefined)
+        hash.update(`${ha1}:${this.nonce}:${ha2}`)
+      else
+        hash.update(`${ha1}:${this.nonce}:${nc}:${cnonce}:${this.qop}:${ha2}`)
+      var response = hash.hex()
+    } else {
+      var response =
+        this.qop === undefined
+          ? new MD5().appendStr(`${ha1}:${this.nonce}:${ha2}`).end().toString()
+          : new MD5()
             .appendStr(
               `${ha1}:${this.nonce}:${nc}:${cnonce}:${this.qop}:${ha2}`,
             )
             .end()
             .toString()
+    }
 
     const authorizationParams: string[] = []
+    if (this.algorithm === 'sha-256')
+      authorizationParams.push(`algorithm="SHA-256"`)
     authorizationParams.push(`username="${this.username}"`)
     authorizationParams.push(`realm="${this.realm}"`)
     authorizationParams.push(`nonce="${this.nonce}"`)

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "process": "0.11.10",
     "stream-browserify": "3.0.0",
     "ts-md5": "1.2.11",
+    "js-sha256": "0.11.0",
     "ws": "8.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Jira Link (use notation [PROJECT-123]): [FB5-1583]
Problem / Feature: See Jira
Solution: See Jira
Testing: See Jira
Jira or PR for parallel or older branches: <Enter link to Jira or another PR or delete this if not needed>
Concerns: None
Expert Reviewers: Any
Sections to be Reviewed: All
Expected maximum review time: 10 minutes

NOTE: Only to be merged after branch fb5_1.3 has been created.

UPDATE: Will need to be cherry-pciked to main instead as FB5 is using that now.


[FB5-1583]: https://ovationsystems.atlassian.net/browse/FB5-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ